### PR TITLE
Set Consistent Height for Calendars

### DIFF
--- a/src/components/features/components/MonthCalendarSelector.tsx
+++ b/src/components/features/components/MonthCalendarSelector.tsx
@@ -151,6 +151,7 @@ export function MonthCalendarSelector({
           'p-3.5 sm:p-4',
           'ring-1 ring-black/5 dark:ring-white/10'
         )}
+        fixedWeeks={true}
         pagedNavigation
         modifiersClassNames={{
           selected: 'selected-day',
@@ -261,7 +262,7 @@ export function MonthCalendarSelector({
             'shadow-sm'
           ),
           day_outside: cn(
-            'text-gray-500 dark:text-gray-500 opacity-50 hover:opacity-70',
+            'text-gray-500 dark:text-gray-500 opacity-30 hover:opacity-70',
             'transition-opacity duration-200'
           ),
           day_disabled: cn(


### PR DESCRIPTION
## Description

**Problem**
- Going through different months on the calendar for **Holidays** or **Company Days Off** changes the `OptimizationForm` height and moves the previous/next month icon away from the cursor
- This only happens when there are optimization results

**This PR's solution**
- Add [fixedWeeks](https://daypicker.dev/docs/customization#fixed-weeks) prop to the `Calendar` component for consistent height

**Tradeoff:** more days outside of month shown
- To address this, the PR also dials down the opacity of days outside the month from `50` to `30` to improve salience of days in month

### Before

<img src="https://github.com/user-attachments/assets/4760f934-07ac-4006-8cca-c20e1908e46d" width="350">

### After

<img src="https://github.com/user-attachments/assets/d6e878d3-c986-49c8-af82-08bf70219601" width="350">
